### PR TITLE
Fix for 117 - adds error to collection

### DIFF
--- a/src/CollectionJson/Collection.cs
+++ b/src/CollectionJson/Collection.cs
@@ -38,6 +38,9 @@ namespace CollectionJson
  
         [DataMember(Name = "template")]
         public Template Template { get; private set; }
+
+        [DataMember(Name = "error")]
+        public Error Error { get; set; }
     }
 
 }

--- a/test/CollectionJson.Client.Tests/CollectionJsonContentTest.cs
+++ b/test/CollectionJson.Client.Tests/CollectionJsonContentTest.cs
@@ -23,5 +23,26 @@ namespace CollectionJson.Client.Tests
             var json = reader.ReadToEnd();
             json.ShouldContain("\"collection\"");
         }
+
+        [Fact]
+        public async void WhenCreatingCollectionJsonContentWithErrorObjectIsSerializedWithError()
+        {
+            var coll = new Collection()
+            {
+                Error = new Error()
+                {
+                    Code = "1234",
+                    Message = "Hello world",
+                    Title = "An error occurred"
+                }
+            };
+            var content = new CollectionJsonContent(coll);
+            var stream = new MemoryStream();
+            await content.CopyToAsync(stream);
+            var reader = new StreamReader(stream);
+            stream.Position = 0;
+            var json = reader.ReadToEnd();
+            json.ShouldContain("\"error\"");
+        }
     }
 }


### PR DESCRIPTION
Fix for #117 - adds error to collection but keeps it optional so it can be null so unless explicitly specified it is not serialized. Added a simple test too.